### PR TITLE
Fix URL to issue list on GitHub

### DIFF
--- a/biblatex-ieee.tex
+++ b/biblatex-ieee.tex
@@ -78,7 +78,7 @@ It is demonstrated in the accompany \textsc{pdf} file
 
 Suggestions for improvement and bug reports can be logged in the package
 issue database, found at
-\url{https://github.com/josephwright/biblatex-ieee/issues/issues}, or can
+\url{https://github.com/josephwright/biblatex-ieee/issues/}, or can
 be sent by e-mail to 
 \href{mailto:joseph.wright@morningstar2.co.uk}
   {\texttt{joseph.wright@morningstar2.co.uk}}.


### PR DESCRIPTION
The URL in biblatex-ieee.tex contains one `issues/` too much. This PR removes it and provides the correct URL to issues: https://github.com/josephwright/biblatex-ieee/issues/