### PR TITLE
Add biblatex-ieee-demo.tex, which uses IEEEtran

### DIFF
--- a/biblatex-ieee-demo.tex
+++ b/biblatex-ieee-demo.tex
@@ -1,0 +1,43 @@
+\documentclass[conference,compsoc]{IEEEtran}
+\usepackage{url}
+\usepackage[style=ieee,backend=biber]{biblatex}
+\usepackage[final]{microtype}
+\usepackage{csquotes}
+\usepackage{balance}
+\usepackage{hyperref}
+
+\hypersetup{hidelinks}
+
+\addbibresource{biblatex-ieee.bib}
+
+\providecommand*{\pkg}[1]{\textsf{#1}}
+
+\begin{document}
+\title{Demonstration of the \pkg{IEEE} bibliography style for \pkg{biblatex}}
+\author{
+    \IEEEauthorblockN{Joseph Wright}
+    \IEEEauthorblockA{
+        E-mail: \href{mailto:joseph.wright@morningstar2.co.uk}{\texttt{joseph.wright@morningstar2.co.uk}}
+    }
+}
+\maketitle
+\IEEEpeerreviewmaketitle
+
+\begin{abstract}
+This document is a demonstration of the biblatex-ieee style.
+\end{abstract}
+
+\section{Introduction}
+Documentation is available in \pkg{biblatex-ieee.pdf}.
+This document just lists all references contained in \pkg{biblatex-ieee.bib} to check the font size and the correct balancing of the columns on the last page.
+
+\nocite{*}
+
+\printbibliography
+
+% IEEE demands that the columns of the last page are balanced
+% \IEEEtriggeratref{30} doesn't work any more
+% Sometimes, \balance helps instead
+\balance
+
+\end{document}


### PR DESCRIPTION
Add `biblatex-ieee-demo.tex`. Similar to `biblatex-ieee.tex`, it lists all references contained in `biblatex-ieee.bib`. However, the layout is based on [IEEEtran](https://www.ctan.org/pkg/ieeetran). The intention is to A) check for the font size and B) demonstrate the correct balancing of columns on the last page.

I think, that the font size doesn't match.

Here the output using `IEEEtran.bst`: (I can provide the file too for completeness; but I didn't know with filename to take `biblatex-ieee-demo-IEEEtran_bst.tex` feels consistent, but also wrong because of the `biblatex-ieee` prefix).

![grabbed_20160328-225801](https://cloud.githubusercontent.com/assets/1366654/14090138/f7c47efa-f538-11e5-80f4-129d1c5ad0dd.png)

Here the output using `biblatex-ieee`:

![grabbed_20160328-230550](https://cloud.githubusercontent.com/assets/1366654/14090278/9fdf13fc-f539-11e5-9ae0-9c73a9652554.png)

Finally, the balancing using `\IEEEtriggeratref{30}` doesn't work any more (refers to case B)).

A) [can be fixed using](http://tex.stackexchange.com/a/1441/9075) `\renewcommand*{\bibfont}{\footnotesize}` right before `\printbibliography`. I am unsure if this should be inlcuded in the bibliography style itself or in `IEEEtran.cls`.

I have no idea how to make `\IEEEtriggeratref` working again. Therefore, I am going to file an issue as soon as this demonstration file is merged.


