### PR TITLE
Add Hungarian localisation

### DIFF
--- a/build.lua
+++ b/build.lua
@@ -18,7 +18,7 @@ typesetsuppfiles = {"*.bib"}
 unpackfiles = { }
 
 -- Install biblatex style files and use these as the sources
-installfiles = {"*.cbx", "*.bbx"}
+installfiles = {"*.cbx", "*.bbx", "*.lbx"}
 sourcefiles  = installfiles
 
 -- Release a TDS-style zip

--- a/ieee.bbx
+++ b/ieee.bbx
@@ -29,6 +29,9 @@
 }
 \uspunctuation
 
+% Load language-specific customizations
+\DeclareLanguageMappingSuffix{-ieee}
+
 % Custom field formats 
 \DeclareFieldFormat[article]{number}{\bibstring{number}\addnbspace#1}
 \DeclareFieldFormat[patent]{number}{\mkonepagegrouped{#1}}

--- a/magyar-ieee.lbx
+++ b/magyar-ieee.lbx
@@ -1,0 +1,24 @@
+\ProvidesFile{magyar-ieee.lbx}
+\InheritBibliographyExtras{magyar}
+
+\DeclareBibliographyStrings{inherit={magyar}}
+
+\DeclareBibliographyExtras{
+  \savefieldformat{number}%
+  \savefieldformat{volume}%
+  \savefieldformat{series}%
+  \DeclareFieldFormat[article, periodical]{number}{\mkbibordinal{#1}\addnbspace\bibstring{number}}%
+%  \DeclareFieldFormat{pages}{\mkpageprefix[bookpagination][\mkpagegrouped]{#1}}
+  \DeclareFieldFormat[book,inbook,incollection,inproceedings]{series}{%
+    \ifnumerals{#1}{\mkbibordinal{#1}}{#1}\addnbspace\bibstring{jourser}}%
+  \DeclareFieldFormat*{volume}{%
+    \ifnumerals{#1}{\mkbibordinal{#1}}{#1}\addnbspace\bibstring{volume}}%
+  \DeclareFieldFormat[article,periodical]{volume}{%
+    \ifnumerals{#1}{\mkbibordinal{#1}}{#1}\addnbspace\bibstring{jourvol}}%
+}
+
+\UndeclareBibliographyExtras{%
+  \restorefieldformat{volume}%
+  \restorefieldformat{number}%
+  \restorefieldformat{series}%
+}

--- a/magyar-ieee.lbx
+++ b/magyar-ieee.lbx
@@ -8,7 +8,6 @@
   \savefieldformat{volume}%
   \savefieldformat{series}%
   \DeclareFieldFormat[article, periodical]{number}{\mkbibordinal{#1}\addnbspace\bibstring{number}}%
-%  \DeclareFieldFormat{pages}{\mkpageprefix[bookpagination][\mkpagegrouped]{#1}}
   \DeclareFieldFormat[book,inbook,incollection,inproceedings]{series}{%
     \ifnumerals{#1}{\mkbibordinal{#1}}{#1}\addnbspace\bibstring{jourser}}%
   \DeclareFieldFormat*{volume}{%


### PR DESCRIPTION
Hungarian requires "3. évf., 2. sz." instead of "vol. 3, no. 2"

See https://github.com/plk/biblatex/issues/717#issuecomment-382848767