### PR TITLE
Add missing % in Hungarian localisation

### DIFF
--- a/magyar-ieee.lbx
+++ b/magyar-ieee.lbx
@@ -1,23 +1,24 @@
 %% ---------------------------------------------------------------
-%% biblatex-ieee --- A biblatex implementation of the IEEE 
+%% biblatex-ieee --- A biblatex implementation of the IEEE
 %%   bibliography style
 %% Maintained by Joseph Wright
 %% E-mail: joseph.wright at morningstar2.co.uk
 %% Released under the LaTeX Project Public License v1.3c or later
 %% See http://www.latex-project.org/lppl.txt
 %% ---------------------------------------------------------------
-%% 
+%%
 
 \ProvidesFile{magyar-ieee.lbx}
 \InheritBibliographyExtras{magyar}
 
 \DeclareBibliographyStrings{inherit={magyar}}
 
-\DeclareBibliographyExtras{
+\DeclareBibliographyExtras{%
   \savefieldformat{number}%
   \savefieldformat{volume}%
   \savefieldformat{series}%
-  \DeclareFieldFormat[article, periodical]{number}{\mkbibordinal{#1}\addnbspace\bibstring{number}}%
+  \DeclareFieldFormat[article, periodical]{number}{%
+    \mkbibordinal{#1}\addnbspace\bibstring{number}}%
   \DeclareFieldFormat[book,inbook,incollection,inproceedings]{series}{%
     \ifnumerals{#1}{\mkbibordinal{#1}}{#1}\addnbspace\bibstring{jourser}}%
   \DeclareFieldFormat*{volume}{%
@@ -32,20 +33,20 @@
   \restorefieldformat{series}%
 }
 
-%% 
+%%
 %% Copyright (C) 2011-2013,2015-2018 by
 %%   Joseph Wright <joseph.wright at morningstar2.co.uk>
-%% 
+%%
 %% It may be distributed and/or modified under the conditions of
 %% the LaTeX Project Public License (LPPL), either version 1.3c of
 %% this license or (at your option) any later version.  The latest
 %% version of this license is in the file:
-%% 
+%%
 %%    http://www.latex-project.org/lppl.txt
-%% 
+%%
 %% This work is "maintained" (as per LPPL maintenance status) by
 %%   Joseph Wright.
-%% 
+%%
 %% This work consists of the files biblatex-ieee.bib,
 %%                                 biblatex-ieee.tex,
 %%                                 ieee.bbx,
@@ -55,6 +56,6 @@
 %%                                 magyar-ieee.lbx,
 %%           and the derived files biblatex-ieee.pdf and
 %%                                 biblatex-ieee-alphabetic.pdf.
-%% 
+%%
 %%
 %% End of file `biblatex-ieee.bib'.


### PR DESCRIPTION
The missing `%` could cause unwanted space to appear in obscure situations.

```latex
\documentclass[magyar,british]{article}
\usepackage[T1]{fontenc}
\usepackage[utf8]{inputenc}
\usepackage{babel}
\usepackage{csquotes}

\usepackage[style=ieee,autolang=other,language=auto,backend=biber]{biblatex}

\usepackage{filecontents}
\begin{filecontents}{\jobname.bib}
@book{hungarian,
  author  = {M. Monty and P. Python},
  title   = {The Hungarian Phrasebook},
  date    = {1970},
  langid  = {magyar},
}
\end{filecontents}

\addbibresource{\jobname.bib}

\begin{document}
A\cite{hungarian}B

\printbibliography
\end{document}
```
gave

> A[   1]B

instead of

> A[1]B