### PR TITLE
Rework rebracketing of citations (#51)

### DIFF
--- a/ieee.cbx
+++ b/ieee.cbx
@@ -1,14 +1,14 @@
 %% ---------------------------------------------------------------
-%% biblatex-ieee --- A biblatex implementation of the IEEE 
+%% biblatex-ieee --- A biblatex implementation of the IEEE
 %%   bibliography style
 %% Maintained by Joseph Wright
 %% E-mail: joseph.wright@morningstar2.co.uk
 %% Released under the LaTeX Project Public License v1.3c or later
 %% See http://www.latex-project.org/lppl.txt
 %% ---------------------------------------------------------------
-%% 
+%%
 
-\ProvidesFile{ieee.cbx}[2019/06/19 v1.3a biblatex citation style]
+\ProvidesFile{ieee.cbx}[2020/02/20 v1.4 biblatex citation style]
 
 \RequireCitationStyle{numeric-comp}
 
@@ -18,62 +18,69 @@
     sorting      = none
 }
 
-% Putting brackets around each citation number is a two-part
-% operation. First, remove them from around the whole citation by
+% Remove the brackets from around the whole citation by
 % redeclaring here.
 \DeclareCiteCommand{\cite}%
   {\usebibmacro{cite:init}%
-   \bibopenbracket
    \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite:comp}}
   {}
   {\usebibmacro{cite:dump}%
-   \usebibmacro{postnote}%
-   \bibclosebracket
-  }
+   \usebibmacro{postnote}}
 
-% The second step is to replace \multicitedelim with a version wrapped in
-% the appropriate delimiter.
-\renewcommand*{\do}[1]{%
-  \expandafter\patchcmd\expandafter
-    {\csname abx@macro@\detokenize{#1}\endcsname}%
-    {\multicitedelim}
-    {\bibclosebracket\multicitedelim\bibopenbracket}
-    {}
-    {%
-      \PackageError{biblatex-ieee}{Failed to update citation style}\@ehc
-    }%
-  }
-\docsvlist{cite:comp:comp,cite:comp:end,cite:comp:inset,cite:dump}
+% Add brackets to the labels directly
+\renewbibmacro*{cite:print:shorthand}{%
+  \printtext[bibhyperref]{%
+    \printtext[brackets]{\printfield{shorthand}}}}
 
-% There's also one \bibrangedash to alter.
-\expandafter\patchcmd\expandafter
-  {\csname abx@macro@\detokenize{cite:dump}\endcsname}%
-  {\bibrangedash}
-  {\bibclosebracket\bibrangedash\bibopenbracket}
-  {}
-  {%
-    \PackageError{biblatex-ieee}{Failed to update citation style}\@ehc
-  }%
+\renewbibmacro*{cite:print:labelnumber}{%
+  \printtext[bibhyperref]{%
+    \printtext[brackets]{%
+      \printfield{labelprefix}%
+      \printfield{labelnumber}%
+      \printfield{entrysetcount}}}}
+
+\renewbibmacro*{cite:print:last:labelnumber}{%
+  \printtext[bibhyperref:lastkey]{%
+    \printtext[brackets]{%
+      \ifdef\cbx@lastprefix
+        {\printtext[labelprefix]{\cbx@lastprefix}}
+        {}%
+      \printtext[labelnumber]{\cbx@lastnumber}%
+      \ifdef\cbx@lastentrysetcount
+        {\printtext[entrysetcount]{\cbx@lastentrysetcount}}
+        {}}}}
+
+% subentries are compressed, but keep their labelnumber,
+% so we can reuse the previous macros (which techincally use
+% a entrysetcount they don't need)
+\renewbibmacro*{cite:print:subentry:comp}{%
+  \usebibmacro{cite:print:labelnumber}}
+
+\renewbibmacro*{cite:print:subentry:full}{%
+  \usebibmacro{cite:print:labelnumber}}
+
+\renewbibmacro*{cite:print:last:subentry:comp}{%
+  \usebibmacro{cite:print:last:labelnumber}}
 
 % More bracket removal required
 \DeclareMultiCiteCommand{\cites}{\cite}{\multicitedelim}
 
-%% 
+%%
 %% Copyright (C) 2011-2013,2015-2018 by
 %%   Joseph Wright <joseph.wright@morningstar2.co.uk>
-%% 
+%%
 %% It may be distributed and/or modified under the conditions of
 %% the LaTeX Project Public License (LPPL), either version 1.3c of
 %% this license or (at your option) any later version.  The latest
 %% version of this license is in the file:
-%% 
+%%
 %%    http://www.latex-project.org/lppl.txt
-%% 
+%%
 %% This work is "maintained" (as per LPPL maintenance status) by
 %%   Joseph Wright.
-%% 
+%%
 %% This work consists of the files biblatex-ieee.bib,
 %%                                 biblatex-ieee.tex,
 %%                                 ieee.bbx,
@@ -83,6 +90,6 @@
 %%                                 magyar-ieee.lbx,
 %%           and the derived files biblatex-ieee.pdf and
 %%                                 biblatex-ieee-alphabetic.pdf.
-%% 
+%%
 %%
 %% End of file `ieee.cbx'.


### PR DESCRIPTION
See #51, cf. https://github.com/plk/biblatex/pull/963 and in particular https://github.com/plk/biblatex/commit/fa6b52e9a384d33b24513d97889ca638eb204ce1, https://github.com/plk/biblatex/commit/0371024a2ee08b00e199e25c8d07376fda45564e, https://github.com/plk/biblatex/commit/4208f41e7e1a07c8e83ab24e22bfc014802ae847.

---

This should probably only be merged once the next version of `biblatex` with those changes is on its way to release. This is more of a reminder for me to make sure that things continue to work.