### PR TITLE
Update cite rebracketing for numeric-comp changes

### DIFF
--- a/ieee.cbx
+++ b/ieee.cbx
@@ -1,12 +1,12 @@
 %% ---------------------------------------------------------------
-%% biblatex-ieee --- A biblatex implementation of the IEEE 
+%% biblatex-ieee --- A biblatex implementation of the IEEE
 %%   bibliography style
 %% Maintained by Joseph Wright
 %% E-mail: joseph.wright@morningstar2.co.uk
 %% Released under the LaTeX Project Public License v1.3c or later
 %% See http://www.latex-project.org/lppl.txt
 %% ---------------------------------------------------------------
-%% 
+%%
 
 \ProvidesFile{ieee.cbx}[2019/06/19 v1.3a biblatex citation style]
 
@@ -33,7 +33,9 @@
    \bibclosebracket
   }
 
-% The second step is to replace \multicitedelim with a version wrapped in
+
+% The second step is to replace \multicitedelim and
+% \multicitesubentrydelim with a version wrapped in
 % the appropriate delimiter.
 \renewcommand*{\do}[1]{%
   \expandafter\patchcmd\expandafter
@@ -45,35 +47,76 @@
       \PackageError{biblatex-ieee}{Failed to update citation style}\@ehc
     }%
   }
-\docsvlist{cite:comp:comp,cite:comp:end,cite:comp:inset,cite:dump}
+\docsvlist{cite:comp:end,cite:comp:inset,cite:comp:shand,cite:dump}
 
-% There's also one \bibrangedash to alter.
+\renewcommand*{\do}[1]{%
+  \expandafter\patchcmd\expandafter
+    {\csname abx@macro@\detokenize{#1}\endcsname}%
+    {\multicitesubentrydelim}
+    {\bibclosebracket\multicitesubentrydelim\bibopenbracket}
+    {}
+    {%
+      \PackageError{biblatex-ieee}{Failed to update citation style}\@ehc
+    }%
+  }
+\docsvlist{cite:comp:inset,cite:dump:inset}
+
+
+% There's also one \multiciterangedelim and one
+% \multicitesubentryrangedelimto alter.
 \expandafter\patchcmd\expandafter
   {\csname abx@macro@\detokenize{cite:dump}\endcsname}%
-  {\bibrangedash}
-  {\bibclosebracket\bibrangedash\bibopenbracket}
+  {\multiciterangedelim}
+  {\bibclosebracket\multiciterangedelim\bibopenbracket}
   {}
   {%
     \PackageError{biblatex-ieee}{Failed to update citation style}\@ehc
   }%
 
+\expandafter\patchcmd\expandafter
+  {\csname abx@macro@\detokenize{cite:dump:inset}\endcsname}%
+  {\multicitesubentryrangedelim}
+  {\bibclosebracket\multicitesubentryrangedelim\bibopenbracket}
+  {}
+  {%
+    \PackageError{biblatex-ieee}{Failed to update citation style}\@ehc
+  }%
+
+
 % More bracket removal required
 \DeclareMultiCiteCommand{\cites}{\cite}{\multicitedelim}
 
-%% 
+% print labelnumber for compressed set entries
+\renewbibmacro*{cite:print:subentry:comp}{%
+  \printtext[bibhyperref]{%
+    \printfield{labelprefix}%
+    \printfield{labelnumber}%
+    \printfield{entrysetcount}}}
+
+\newbibmacro*{cite:print:last:subentry:comp}{%
+  \printtext[bibhyperref:lastkey]{%
+    \ifdef\cbx@lastprefix
+      {\printtext[labelprefix]{\cbx@lastprefix}}
+      {}%
+    \printtext[labelnumber]{\cbx@lastnumber}%
+    \ifdef\cbx@lastentrysetcount
+      {\printtext[entrysetcount]{\cbx@lastentrysetcount}}
+      {}}}
+
+%%
 %% Copyright (C) 2011-2013,2015-2018 by
 %%   Joseph Wright <joseph.wright@morningstar2.co.uk>
-%% 
+%%
 %% It may be distributed and/or modified under the conditions of
 %% the LaTeX Project Public License (LPPL), either version 1.3c of
 %% this license or (at your option) any later version.  The latest
 %% version of this license is in the file:
-%% 
+%%
 %%    http://www.latex-project.org/lppl.txt
-%% 
+%%
 %% This work is "maintained" (as per LPPL maintenance status) by
 %%   Joseph Wright.
-%% 
+%%
 %% This work consists of the files biblatex-ieee.bib,
 %%                                 biblatex-ieee.tex,
 %%                                 ieee.bbx,
@@ -83,6 +126,6 @@
 %%                                 magyar-ieee.lbx,
 %%           and the derived files biblatex-ieee.pdf and
 %%                                 biblatex-ieee-alphabetic.pdf.
-%% 
+%%
 %%
 %% End of file `ieee.cbx'.

--- a/ieee.cbx
+++ b/ieee.cbx
@@ -93,7 +93,7 @@
     \printfield{labelnumber}%
     \printfield{entrysetcount}}}
 
-\newbibmacro*{cite:print:last:subentry:comp}{%
+\renewbibmacro*{cite:print:last:subentry:comp}{%
   \printtext[bibhyperref:lastkey]{%
     \ifdef\cbx@lastprefix
       {\printtext[labelprefix]{\cbx@lastprefix}}


### PR DESCRIPTION
Second attempt (see #52): This time it hopefully works...

See #51, cf. https://github.com/plk/biblatex/pull/963 and in particular https://github.com/plk/biblatex/commit/fa6b52e9a384d33b24513d97889ca638eb204ce1, https://github.com/plk/biblatex/commit/0371024a2ee08b00e199e25c8d07376fda45564e, https://github.com/plk/biblatex/commit/4208f41e7e1a07c8e83ab24e22bfc014802ae847.

---

Again, this should probably only be merged when `biblatex` 3.15 with https://github.com/plk/biblatex/pull/963 is released.