### PR TITLE
Make dashed=false the default (#60)

### DIFF
--- a/ieee-alphabetic.bbx
+++ b/ieee-alphabetic.bbx
@@ -27,7 +27,7 @@
   {\list
      {\printtext[labelalphawidth]{%
         \printfield{labelprefix}%
-	\printfield{labelalpha}%
+        \printfield{labelalpha}%
         \printfield{extraalpha}}}
      {\setlength{\labelwidth}{\labelalphawidth}%
       \setlength{\leftmargin}{\labelwidth}%

--- a/ieee.bbx
+++ b/ieee.bbx
@@ -13,6 +13,8 @@
 % Load the standard style to avoid copy-pasting unnecessary material
 \RequireBibliographyStyle{numeric-comp}
 
+\newbibmacro*{bbx:savehash}{\savefield{fullhash}{\bbx@lasthash}}
+
 % An option that carries through from author-year styles
 \DeclareBibliographyOption[boolean]{dashed}[true]{%
   \ifstrequal{#1}{true}
@@ -26,7 +28,8 @@
   minnames = 1,
   maxcitenames = 2,
   maxbibnames  = 6,
-  sorting  = none
+  sorting  = none,
+  dashed = false,
 }
 \uspunctuation
 
@@ -84,7 +87,6 @@
 % Support for dashed author name replacement
 \InitializeBibliographyStyle{\global\undef\bbx@lasthash}
 
-\newbibmacro*{bbx:savehash}{\savefield{fullhash}{\bbx@lasthash}}
 
 % Bibliography macros
 \renewbibmacro*{author}{%


### PR DESCRIPTION
This makes `dashed=false,` the default. Needed one small code reordering so the default `\ExecuteBibliographyOptions` setting is not overridden by the later `\newbibmacro`.