### PR TITLE
Fix brackets in \supercite

### DIFF
--- a/ieee.cbx
+++ b/ieee.cbx
@@ -33,6 +33,24 @@
    \bibclosebracket
   }
 
+\DeclareCiteCommand{\supercite}[\mkbibsuperscript]
+  {\usebibmacro{cite:init}%
+   \bibopenbracket
+   \let\multicitedelim=\supercitedelim
+   \let\multicitesubentrydelim=\supercitesubentrydelim
+   \let\multiciterangedelim=\superciterangedelim
+   \let\multicitesubentryrangedelim=\supercitesubentryrangedelim
+   \iffieldundef{prenote}
+     {}
+     {\BibliographyWarning{Ignoring prenote argument}}%
+   \iffieldundef{postnote}
+     {}
+     {\BibliographyWarning{Ignoring postnote argument}}}
+  {\usebibmacro{citeindex}%
+   \usebibmacro{cite:comp}}
+  {}
+  {\usebibmacro{cite:dump}%
+   \bibclosebracket}
 
 % The second step is to replace \multicitedelim and
 % \multicitesubentrydelim with a version wrapped in


### PR DESCRIPTION
Cf. https://tex.stackexchange.com/q/592470/

The following MWE causes mismatched brackets errors
```latex
\documentclass[british]{article}
\usepackage[T1]{fontenc}
\usepackage{babel}
\usepackage{csquotes}

\usepackage[natbib=true,
            style=ieee,
            sortcites=true,
            autocite=superscript,
            backend=biber]{biblatex}
\addbibresource{biblatex-examples.bib}

\begin{document}
Lorem \autocite{sigfridsson,worman,geer}

ipsum \autocites{sigfridsson,worman,geer}{nussbaum}

dolor \supercite{sigfridsson,worman,geer}

sit \parencite{sigfridsson,worman,geer}

sit \cites{sigfridsson,worman,geer}{nussbaum}

sit \cites{sigfridsson,worman,geer}
\end{document}
\end{document}
```
because `\supercite` does not have opening and closing brackets around the entire thing.

This PR fixes that by adding explicit brackets to `\supercite` as well.