### PR TITLE
Fix name list truncation for text references.

### DIFF
--- a/ieee.cbx
+++ b/ieee.cbx
@@ -13,8 +13,8 @@
 \RequireCitationStyle{numeric-comp}
 
 \ExecuteBibliographyOptions{
-    maxcitenames = 3,
-    minnames     = 3,
+    maxcitenames = 2,
+    minnames     = 1,
     sorting      = none
 }
 


### PR DESCRIPTION
While `ieee.bbx` was fixed to address the problem mentioned in #59, the file `ieee.cbx` wasn't. So, text references have accordingly been incorrect.