### PR TITLE
Remove trailing dot from url

### DIFF
--- a/ieee.bbx
+++ b/ieee.bbx
@@ -347,8 +347,12 @@
 
 \renewbibmacro*{url+urldate}{%
   \usebibmacro{urldate}%
-  \setunit{\adddot\space}%
-  \usebibmacro{url}%
+  \iffieldundef{url}
+      {}
+      {\setunit{\adddot\space}%
+       \usebibmacro{url}\nopunct}%
+  %\setunit{\adddot\space}%
+  %\usebibmacro{url}\nopunct%
 }
 
 \renewbibmacro*{urldate}{%

--- a/ieee.bbx
+++ b/ieee.bbx
@@ -50,7 +50,7 @@
 \DeclareFieldFormat[incollection,inproceedings]{series}
   {\bibstring{jourser}\addnbspace#1}
 \DeclareFieldFormat[online,report]{title}{\mkbibquote{#1\isdot}}
-\DeclareFieldFormat{url}{\bibstring{url}\addcolon\space\url{#1}}
+\DeclareFieldFormat{url}{\bibstring{url}\addcolon\space\url{#1}\nopunct}
 \DeclareFieldFormat{urldate}{\bibstring{urlseen}\space#1}
 \DeclareFieldFormat*{volume}
   {\bibstring{volume}\addnbspace#1}
@@ -347,12 +347,8 @@
 
 \renewbibmacro*{url+urldate}{%
   \usebibmacro{urldate}%
-  \iffieldundef{url}
-      {}
-      {\setunit{\adddot\space}%
-       \usebibmacro{url}\nopunct}%
-  %\setunit{\adddot\space}%
-  %\usebibmacro{url}\nopunct%
+  \setunit{\adddot\space}%
+  \usebibmacro{url}%
 }
 
 \renewbibmacro*{urldate}{%


### PR DESCRIPTION
Removes trailing punctuation (e.g., a period) immediately following the URL to comply with the IEEE referencing standard.