### PR TITLE
Add support for shortjournal

### DIFF
--- a/ieee.bbx
+++ b/ieee.bbx
@@ -210,17 +210,26 @@
 }
 
 \renewbibmacro*{journal}{%
-  \iffieldundef{journaltitle}
-    {}
+  \iffieldundef{shortjournal}
+    {%
+      \iffieldundef{journaltitle}
+        {}
+        {%
+          \printtext[journaltitle]{%
+          \printfield[titlecase]{journaltitle}%
+          \setunit{\subtitlepunct}%
+          \printfield[titlecase]{journalsubtitle}%
+          }%
+        }%
+    }
     {%
       \printtext[journaltitle]{%
-         \printfield[titlecase]{journaltitle}%
-         \setunit{\subtitlepunct}%
-         \printfield[titlecase]{journalsubtitle}%
+      \printfield[titlecase]{shortjournal}%
       }%
     }%
   \midsentence
 }
+
 
 \renewbibmacro*{journal+issuetitle}{%
   \usebibmacro{journal}%


### PR DESCRIPTION
This update adds support for the shortjournal field in BibLaTeX, which contains the abbreviated journal title often provided by reference managers like Zotero. According to IEEE referencing guidelines, journal titles should be abbreviated, so when shortjournal is present, it will now be used in place of journaltitle.